### PR TITLE
Initialize pnpm workspace

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint", "prettier"],
+  "extends": [
+    "airbnb-base",
+    "airbnb-typescript/base",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
+  ],
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "ignorePatterns": ["dist", "node_modules"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": true
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@prompt-lab/api",
+  "private": true,
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "build": "tsc"
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,1 @@
+export default () => 'api';

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@prompt-lab/web",
+  "private": true,
+  "version": "0.0.0",
+  "main": "src/main.tsx",
+  "scripts": {
+    "dev": "echo 'web dev'",
+    "build": "tsc"
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,1 @@
+export default () => 'web';

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "prompt-lab",
+  "private": true,
+  "version": "0.0.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "concurrently \"pnpm --filter ./apps/api dev\" \"pnpm --filter ./apps/web dev\"",
+    "test": "echo \"No tests yet\"",
+    "test:e2e": "echo \"No e2e tests yet\"",
+    "lint": "eslint \"**/*.{ts,tsx}\"",
+    "format": "prettier --write ."
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^2.8.8",
+    "typescript": "^5.0.0",
+    "concurrently": "^8.0.0",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@prompt-lab/evaluator",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/packages/evaluator/src/index.ts
+++ b/packages/evaluator/src/index.ts
@@ -1,0 +1,1 @@
+export default () => 'evaluator';

--- a/packages/evaluator/tsconfig.json
+++ b/packages/evaluator/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/test-cases/package.json
+++ b/packages/test-cases/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@prompt-lab/test-cases",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/packages/test-cases/src/index.ts
+++ b/packages/test-cases/src/index.ts
@@ -1,0 +1,1 @@
+export default ['example'];

--- a/packages/test-cases/tsconfig.json
+++ b/packages/test-cases/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["apps/**/*", "packages/**/*"]
+}


### PR DESCRIPTION
## Summary
- bootstrap pnpm monorepo with apps and packages
- add root TypeScript config, ESLint, and Prettier configs
- wire up scripts for dev, test, lint, and format

## Testing
- `pnpm dev`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm -r exec tsc --noEmit`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685a9da3cba08329b12e2e2e9591b5f5