### PR TITLE
Add evaluator library

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:web": "pnpm --filter web run dev",
     "dev": "concurrently \"pnpm dev:api\" \"pnpm dev:web\"",
     "tsc": "pnpm exec tsc --noEmit -p tsconfig.json",
-    "test": "pnpm tsc && vitest run",
+    "test": "pnpm tsc && vitest run --coverage",
     "test:e2e": "echo \"No e2e tests yet\"",
     "lint": "eslint \"**/*.{ts,tsx}\"",
     "format": "prettier --write ."
@@ -33,6 +33,7 @@
     "ts-node": "^10.9.1",
     "typescript": "4.9.5",
     "vite": "7.0.0",
-    "vitest": "1.5.0"
+    "vitest": "1.5.0",
+    "@vitest/coverage-istanbul": "1.5.0"
   }
 }

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -1,9 +1,15 @@
 {
   "name": "@prompt-lab/evaluator",
   "version": "0.0.0",
+  "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "vitest run --coverage"
+  },
+  "dependencies": {
+    "openai": "^4.26.0",
+    "p-limit": "^5.0.0"
   }
 }

--- a/packages/evaluator/src/index.ts
+++ b/packages/evaluator/src/index.ts
@@ -1,1 +1,60 @@
-export default () => 'evaluator';
+import type OpenAI from 'openai';
+import pLimit from 'p-limit';
+
+function applyTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(
+    /{{\s*(\w+)\s*}}/g,
+    (_, key: string) => vars[key] ?? '',
+  );
+}
+
+async function scorePair(
+  openai: OpenAI,
+  prediction: string,
+  reference: string,
+  model = 'text-embedding-3-small',
+): Promise<number> {
+  const [
+    {
+      data: [pred],
+    },
+    {
+      data: [ref],
+    },
+  ] = await Promise.all([
+    openai.embeddings.create({ model, input: prediction }),
+    openai.embeddings.create({ model, input: reference }),
+  ]);
+
+  const a = pred.embedding;
+  const b = ref.embedding;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    dot += a[i] * b[i];
+    normA += a[i] ** 2;
+    normB += b[i] ** 2;
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+export interface BatchItem {
+  prediction: string;
+  reference: string;
+}
+
+async function runBatch(
+  openai: OpenAI,
+  items: BatchItem[],
+  concurrency = 5,
+): Promise<number[]> {
+  const limit = pLimit(concurrency);
+  return Promise.all(
+    items.map((it) =>
+      limit(() => scorePair(openai, it.prediction, it.reference)),
+    ),
+  );
+}
+
+export { applyTemplate, scorePair, runBatch };

--- a/packages/evaluator/test/evaluator.test.ts
+++ b/packages/evaluator/test/evaluator.test.ts
@@ -1,0 +1,78 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import type OpenAI from 'openai';
+import { applyTemplate, scorePair, runBatch, BatchItem } from '../src/index.js';
+
+class MockOpenAI {
+  embeddings = {
+    create: vi.fn(async ({ input }: { input: string }) => {
+      const vec = this.map[input as keyof typeof this.map] || [0, 0];
+      return { data: [{ embedding: vec }] } as {
+        data: { embedding: number[] }[];
+      };
+    }),
+  };
+
+  constructor(private map: Record<string, number[]>) {}
+}
+
+describe('applyTemplate', () => {
+  it('replaces placeholders with values', () => {
+    const out = applyTemplate('hi {{name}}', { name: 'Sam' });
+    expect(out).toBe('hi Sam');
+  });
+});
+
+describe('scorePair', () => {
+  it('computes cosine similarity using embeddings', async () => {
+    const openai = new MockOpenAI({
+      a: [1, 2],
+      b: [1, 0],
+    }) as unknown as OpenAI;
+    const score = await scorePair(openai, 'a', 'b');
+    const expected = 1 / Math.sqrt(5); // dot=1, |a|=sqrt(5), |b|=1
+    expect(score).toBeCloseTo(expected);
+    expect(
+      (openai as unknown as { embeddings: { create: Mock } }).embeddings.create,
+    ).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('runBatch', () => {
+  it('respects concurrency limit', async () => {
+    const calls: string[] = [];
+    const openai = new MockOpenAI({
+      x: [1, 0],
+      y: [1, 0],
+    }) as unknown as OpenAI;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    (
+      openai as unknown as { embeddings: { create: Mock } }
+    ).embeddings.create.mockImplementation(
+      async ({ input }: { input: string }) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 10);
+        });
+        inFlight -= 1;
+        calls.push(input);
+        return { data: [{ embedding: [1, 0] }] } as {
+          data: { embedding: number[] }[];
+        };
+      },
+    );
+
+    const items: BatchItem[] = [
+      { prediction: 'x', reference: 'y' },
+      { prediction: 'x', reference: 'y' },
+    ];
+
+    const scores = await runBatch(openai, items, 1);
+
+    expect(scores).toEqual([1, 1]);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+    expect(calls).toHaveLength(4); // 2 items * 2 calls each
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,6 +7,20 @@ export default defineConfig({
     mockReset: true,
     hookTimeout: 5000,
     deps: { inline: [/vitest/] },
-    coverage: { reporter: ['text', 'json'] },
+    coverage: {
+      provider: 'istanbul',
+      reporter: ['text', 'json'],
+      thresholds: {
+        statements: 0,
+        branches: 0,
+        functions: 0,
+        lines: 0,
+        'packages/evaluator/**': {
+          statements: 90,
+          functions: 90,
+          lines: 90,
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- implement evaluator core functions: applyTemplate, scorePair, runBatch
- add OpenAI and concurrency utilities
- enforce coverage thresholds per evaluator package
- create unit tests with OpenAI mocks
- export evaluator functions for other packages

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test`
- `pnpm --filter evaluator test`


------
https://chatgpt.com/codex/tasks/task_e_685aabbaae088329b28ee08b3302b29e