### PR TITLE
Add JSONL fixtures and linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "pnpm tsc && vitest run --coverage",
     "test:e2e": "echo \"No e2e tests yet\"",
     "lint": "eslint \"**/*.{ts,tsx}\"",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "lint:data": "node scripts/lint-jsonl.cjs"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/packages/test-cases/news-summaries.jsonl
+++ b/packages/test-cases/news-summaries.jsonl
@@ -1,0 +1,15 @@
+{"id":"1","input":"Tech stocks rallied today sending the market higher.","expected":"Market climbs as tech stocks rally."}
+{"id":"2","input":"The city council approved new green initiatives.","expected":"Council backs new eco measures."}
+{"id":"3","input":"Scientists discovered a potential cure for the rare disease.","expected":"New discovery offers hope for curing rare disease."}
+{"id":"4","input":"Heavy rains caused flooding across the region.","expected":"Region hit by floods after heavy rains."}
+{"id":"5","input":"A local team won the championship after a tense final.","expected":"Local champions triumph in tense final."}
+{"id":"6","input":"The government announced tax cuts for small businesses.","expected":"Small businesses to benefit from tax cuts."}
+{"id":"7","input":"An ancient shipwreck was found near the coastline.","expected":"Archaeologists uncover ancient shipwreck."}
+{"id":"8","input":"The art exhibition attracted thousands of visitors.","expected":"Large crowds drawn to art exhibition."}
+{"id":"9","input":"A new restaurant opened offering plant-based dishes.","expected":"Plant-based eatery opens to public."}
+{"id":"10","input":"Meteorologists predict a severe storm this weekend.","expected":"Severe storm expected this weekend."}
+{"id":"11","input":"The charity event raised record-breaking donations.","expected":"Charity event sets donation record."}
+{"id":"12","input":"Researchers developed a faster charging battery.","expected":"New battery charges devices more quickly."}
+{"id":"13","input":"Local schools will start later to improve sleep.","expected":"Later start times planned for local schools."}
+{"id":"14","input":"The theater announced a lineup of classic plays.","expected":"Classic plays scheduled at local theater."}
+{"id":"15","input":"A tech company unveiled its latest smartphone model.","expected":"New smartphone model revealed by tech company."}

--- a/scripts/lint-jsonl.cjs
+++ b/scripts/lint-jsonl.cjs
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+function collectJsonl(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return collectJsonl(fullPath);
+    }
+    return entry.name.endsWith('.jsonl') ? [fullPath] : [];
+  });
+}
+
+let hasError = false;
+for (const file of collectJsonl(process.cwd())) {
+  const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/).filter(Boolean);
+  lines.forEach((line, idx) => {
+    try {
+      JSON.parse(line);
+    } catch (err) {
+      console.error(`${file}:${idx + 1} ${err.message}`);
+      hasError = true;
+    }
+  });
+}
+if (hasError) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- create `news-summaries.jsonl` fixture with 15 synthetic entries
- add `lint:data` script that JSON-lints all `.jsonl` files
- implement JSONL linting script

## Testing
- `pnpm lint:data`
- `pnpm lint`
- `pnpm tsc`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ab0b53d748329b221a50c66b8094c