### PR TITLE
Switch API to ts-node ESM mode

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,9 +2,10 @@
   "name": "@prompt-lab/api",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "dev": "ts-node-dev src/index.ts",
+    "dev": "ts-node-dev --loader ts-node/esm src/index.ts",
     "build": "tsc"
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,8 @@
+import { fileURLToPath } from 'url';
 import express from 'express';
-import { z } from 'zod';
 import dotenv from 'dotenv';
+import { z } from 'zod';
+import evalRouter from './routes/eval.js';
 
 dotenv.config();
 
@@ -11,16 +13,7 @@ app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-const evalSchema = z.object({
-  promptTemplate: z.string(),
-  model: z.string(),
-  testSetId: z.string(),
-});
-
-app.post('/eval', (req, res) => {
-  const parsed = evalSchema.parse(req.body);
-  res.json(parsed);
-});
+app.use('/eval', evalRouter);
 
 const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
@@ -28,7 +21,9 @@ const envSchema = z.object({
 
 const { PORT } = envSchema.parse(process.env);
 
-if (require.main === module) {
+const isEntry = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isEntry) {
   app.listen(PORT, () => {
     // eslint-disable-next-line no-console
     console.log(`API listening on port ${PORT}`);

--- a/apps/api/src/routes/eval.ts
+++ b/apps/api/src/routes/eval.ts
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { z } from 'zod';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
+const __filename = fileURLToPath(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
+const __dirname = path.dirname(__filename);
+
+const router = Router();
+
+const evalSchema = z.object({
+  promptTemplate: z.string(),
+  model: z.string(),
+  testSetId: z.string(),
+});
+
+router.post('/', (req, res) => {
+  const parsed = evalSchema.parse(req.body);
+  // Example path usage to locate test cases
+  const testCasesPath = path.join(
+    __dirname,
+    '../../../packages/test-cases/news-summaries.jsonl',
+  );
+  // For now we don't read the file, but ensure the path resolves correctly
+  if (!testCasesPath) {
+    res.status(500).end();
+    return;
+  }
+  res.json(parsed);
+});
+
+export default router;

--- a/apps/api/test/eval.test.ts
+++ b/apps/api/test/eval.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import { beforeAll, afterAll, describe, it } from 'vitest';
-import { app } from '../src/index';
+import { app } from '../src/index.js';
 
 let server: ReturnType<typeof app.listen>;
 

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -2,7 +2,7 @@
 import request from 'supertest';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, it } from 'vitest';
-import { app } from '../src/index';
+import { app } from '../src/index.js';
 
 process.env.PORT = process.env.PORT || '3000';
 


### PR DESCRIPTION
## Summary
- enable ESM for API package
- load router through extension-aware import
- use `process.argv` to check entry point
- add router file with `fileURLToPath`-based `__dirname`

## Testing
- `pnpm exec eslint "**/*.{ts,tsx}"`
- `pnpm exec tsc --noEmit -p tsconfig.json`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm dev` *(terminated after launch)*


------
https://chatgpt.com/codex/tasks/task_e_685abb927964832994b25f805219be1d