### PR TITLE
Add evaluator dependency

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "zod": "^3.22.2",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "@prompt-lab/evaluator": "workspace:*"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",


### PR DESCRIPTION
## Summary
- add `@prompt-lab/evaluator` to the API dependencies

## Testing
- `pnpm dev` *(fails: ts-node-dev run then manual SIGINT)*
- `pnpm test`
- `pnpm test:e2e`
- `pnpm run tsc`
- `pnpm lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_685abb92f04c83298dedbe7c8a88205c