### PR TITLE
Add OPENAI key check for eval route

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
-import { z } from 'zod';
 import dotenv from 'dotenv';
+import { z } from 'zod';
+import evalRoutes from './routes/eval.js';
 
 dotenv.config();
 
@@ -11,16 +12,7 @@ app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-const evalSchema = z.object({
-  promptTemplate: z.string(),
-  model: z.string(),
-  testSetId: z.string(),
-});
-
-app.post('/eval', (req, res) => {
-  const parsed = evalSchema.parse(req.body);
-  res.json(parsed);
-});
+app.use('/eval', evalRoutes);
 
 const envSchema = z.object({
   PORT: z.coerce.number().default(3000),

--- a/apps/api/src/routes/eval.ts
+++ b/apps/api/src/routes/eval.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { z } from 'zod';
+
+const router = Router();
+
+const evalSchema = z.object({
+  promptTemplate: z.string(),
+  model: z.string(),
+  testSetId: z.string(),
+});
+
+router.post('/', (req, res) => {
+  const parsed = evalSchema.parse(req.body);
+
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(200).json({
+      ...parsed,
+      completion: 'mock: OPENAI_API_KEY missing',
+    });
+  }
+
+  return res.json(parsed);
+});
+
+export default router;

--- a/apps/api/test/eval.test.ts
+++ b/apps/api/test/eval.test.ts
@@ -27,4 +27,20 @@ describe('POST /eval', () => {
       .expect('Content-Type', /json/)
       .expect(payload);
   });
+
+  it('mocks completion when OPENAI_API_KEY missing', async () => {
+    delete process.env.OPENAI_API_KEY;
+    const payload = {
+      promptTemplate: 'Hello, {{name}}',
+      model: 'gpt-4',
+      testSetId: '1',
+    };
+
+    await request('http://localhost:3001')
+      .post('/eval')
+      .send(payload)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect({ ...payload, completion: 'mock: OPENAI_API_KEY missing' });
+  });
 });


### PR DESCRIPTION
## Summary
- add POST /eval router
- return mock output when OPENAI_API_KEY isn't set
- update tests for fallback behavior

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint`
- `pnpm format`
- `pnpm tsc`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_685ac0af4fcc83299aff85f61d5c6750