### PR TITLE
api: unify ESM + evaluator + key-guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "dev": "ts-node-dev src/index.ts",
+    "dev": "node --loader ts-node/esm src/index.ts",
     "build": "tsc"
+  },
+  "imports": {
+    "evaluator": "../../packages/evaluator/src/index.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { z } from 'zod';
 import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
 import evalRouter from './routes/eval.js';
 
 dotenv.config();
@@ -20,7 +21,9 @@ const envSchema = z.object({
 
 const { PORT } = envSchema.parse(process.env);
 
-if (require.main === module) {
+// eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] === __filename) {
   app.listen(PORT, () => {
     // eslint-disable-next-line no-console
     console.log(`API listening on port ${PORT}`);

--- a/apps/api/test/eval.int.test.ts
+++ b/apps/api/test/eval.int.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file, @typescript-eslint/lines-between-class-members */
 import request from 'supertest';
 import { beforeAll, afterAll, describe, it, expect, vi } from 'vitest';
 
@@ -46,7 +47,19 @@ afterAll(() => {
 });
 
 describe('POST /eval integration', () => {
-  it('evaluates prompt over dataset', async () => {
+  it('503 when key missing', async () => {
+    delete process.env.OPENAI_API_KEY;
+    const res = await request('http://localhost:3002').post('/eval').send({
+      promptTemplate: '{{input}}',
+      model: 'gpt-4.1-mini',
+      testSetId: 'news-summaries',
+    });
+
+    expect(res.status).toBe(503);
+  });
+
+  it('evaluates prompt over dataset with key', async () => {
+    process.env.OPENAI_API_KEY = 'test';
     const res = await request('http://localhost:3002').post('/eval').send({
       promptTemplate: '{{input}}',
       model: 'gpt-4.1-mini',

--- a/apps/api/test/eval.test.ts
+++ b/apps/api/test/eval.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file, @typescript-eslint/lines-between-class-members */
 import request from 'supertest';
 import { beforeAll, afterAll, describe, it, expect, vi } from 'vitest';
 
@@ -46,7 +47,19 @@ afterAll(() => {
 });
 
 describe('POST /eval', () => {
-  it('returns evaluation results', async () => {
+  it('503 when key missing', async () => {
+    delete process.env.OPENAI_API_KEY;
+    const res = await request('http://localhost:3001').post('/eval').send({
+      promptTemplate: '{{input}}',
+      model: 'gpt-4.1-mini',
+      testSetId: 'news-summaries',
+    });
+
+    expect(res.status).toBe(503);
+  });
+
+  it('returns evaluation results with key', async () => {
+    process.env.OPENAI_API_KEY = 'test';
     const res = await request('http://localhost:3001').post('/eval').send({
       promptTemplate: '{{input}}',
       model: 'gpt-4.1-mini',

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "evaluator": ["../../packages/evaluator/src/index.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
     "ignoreDeprecations": "5.0",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "evaluator": ["packages/evaluator/src/index.ts"]
+    }
   },
   "include": ["apps/**/*", "packages/**/*", "vitest.config.mts"]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      evaluator: resolve('packages/evaluator/src/index.ts'),
+    },
+  },
   test: {
     environment: 'node',
     allowOnly: false,


### PR DESCRIPTION
## Summary
- rewrite /eval to use evaluator alias and key check
- convert API to proper ESM bootstrap
- add tsconfig path mapping and vitest alias
- guard tests for missing API key

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ac686c7f48329841c56c4b1797e2a