### PR TITLE
Connect web RunButton to eval API

### DIFF
--- a/apps/web/src/components/PromptEditor.tsx
+++ b/apps/web/src/components/PromptEditor.tsx
@@ -1,3 +1,14 @@
-const PromptEditor = () => <textarea data-testid="prompt-editor" />;
+interface Props {
+  value: string;
+  onChange: (val: string) => void;
+}
+
+const PromptEditor = ({ value, onChange }: Props) => (
+  <textarea
+    data-testid="prompt-editor"
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+  />
+);
 
 export default PromptEditor;

--- a/apps/web/src/components/ResultsTable.tsx
+++ b/apps/web/src/components/ResultsTable.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  perItemCount: number;
+  avgCosSim: number;
+}
+
+const ResultsTable = ({ perItemCount, avgCosSim }: Props) => (
+  <table>
+    <tbody>
+      <tr>
+        <td>Items</td>
+        <td data-testid="perItemCount">{perItemCount}</td>
+      </tr>
+      <tr>
+        <td>Avg CosSim</td>
+        <td data-testid="avgCosSim">{avgCosSim}</td>
+      </tr>
+    </tbody>
+  </table>
+);
+
+export default ResultsTable;

--- a/apps/web/src/components/RunButton.tsx
+++ b/apps/web/src/components/RunButton.tsx
@@ -1,10 +1,11 @@
 interface Props {
   onRun: () => void;
+  loading?: boolean;
 }
 
-const RunButton = ({ onRun }: Props) => (
-  <button type="button" onClick={onRun}>
-    Run
+const RunButton = ({ onRun, loading = false }: Props) => (
+  <button type="button" onClick={onRun} disabled={loading}>
+    {loading ? 'Running...' : 'Run'}
   </button>
 );
 

--- a/apps/web/test/App.test.tsx
+++ b/apps/web/test/App.test.tsx
@@ -1,9 +1,22 @@
-import { describe, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, vi, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../src/App.js';
 
 describe('App', () => {
-  it('renders', () => {
+  it('fetches and displays results', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ perItem: Array(3), aggregates: { avgCosSim: 0.7 } }),
+    })) as unknown as typeof fetch;
+
     render(<App />);
+    fireEvent.change(screen.getByTestId('prompt-editor'), {
+      target: { value: 'hi {{input}}' },
+    });
+    fireEvent.click(screen.getByText('Run'));
+
+    await waitFor(() => screen.getByTestId('perItemCount'));
+    expect(screen.getByTestId('perItemCount').textContent).toBe('3');
+    expect(screen.getByTestId('avgCosSim').textContent).toBe('0.7');
   });
 });


### PR DESCRIPTION
## Summary
- wire RunButton to POST /eval
- show avg cosine similarity and item count in new ResultsTable
- surface loading and error states
- expand web test to mock fetch and verify rendering

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test`
- `pnpm dev` *(fails: Cannot find package 'async_hooks')*

------
https://chatgpt.com/codex/tasks/task_e_685ad3e2ca408329b413f20114b87043