### PR TITLE
Ignore test coverage directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules
 .env
 
 tsconfig.tsbuildinfo
+
+# Ignore coverage output
+coverage/
+coverage-*/
+.coverage/
+**/coverage/


### PR DESCRIPTION
## Summary
- ignore generated coverage directories in `.gitignore`

## Testing
- `pnpm dev` *(fails: ELIFECYCLE Command failed after manual termination)*
- `pnpm test`
- `pnpm test:e2e`
- `pnpm tsc`
- `pnpm lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_685bcb0390388329a19635d818125d68