### PR TITLE
Fix evaluator alias for Vitest

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,7 +4,7 @@ import { resolve } from 'path';
 export default defineConfig({
   resolve: {
     alias: {
-      evaluator: resolve('packages/evaluator/src/index.ts'),
+      '@prompt-lab/evaluator': resolve('packages/evaluator/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- make root Vitest config use @prompt-lab/evaluator alias

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_685c261e5634832989ab194a9522a3f4