### PR TITLE
Update docs with coverage and lint requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Agents must run the full command suite above before opening PRs.
 ## 5. Merge Policy
 
 1. PR-only, never push straight to `main`.
-2. CI green on Node 18 & 22, no coverage regressions, zero ESLint warnings.
+2. CI green on Node 18 & 22, evaluator coverage ≥90%, zero ESLint warnings.
 3. Human reviewer may require changes; agent amends the PR.
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - **Cost & latency tracking** baked into every run.
 - **React UI** with history pane — no backend refresh.
 - **CI gate** fails if your latest prompt degrades benchmark.
+- **Coverage gate**: `@prompt-lab/evaluator` must keep ≥90% test coverage;
+  any ESLint warning fails CI.
 - **Monorepo** (`pnpm`) with strict TypeScript.
 
 ---
@@ -92,6 +94,8 @@ Then hit `http://localhost:3000/health`.
 | `pnpm test:e2e`             | Full prompt-eval; fails if `avgCosSim < 0.7` |
 | `pnpm tsc`                  | Type-check all pkgs                          |
 | `pnpm lint` / `pnpm format` | Lint & auto-format                           |
+
+Run `pnpm test` and `pnpm lint` locally to catch coverage or lint issues before opening a PR.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that evaluator coverage must stay above 90%
- note that any ESLint warning fails CI
- add tip on running `pnpm test` and `pnpm lint` locally

## Testing
- `pnpm test`
- `pnpm test:e2e`
- `pnpm -r tsc`
- `pnpm -r lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_685c26209bf483299714e8ffa8ee30e3