### PR TITLE
Serve built web UI via Express

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,14 @@ app.get('/health', (_req, res) => {
 
 app.use('/eval', evalRouter);
 
+// Serve built web UI from /public when present
+app.use(express.static(join(rootDir, 'public')));
+
+// Fallback to index.html for SPA routing
+app.get('*', (_req, res) => {
+  res.sendFile(join(rootDir, 'public', 'index.html'));
+});
+
 app.use(
   (
     err: unknown,

--- a/apps/api/src/routes/eval.ts
+++ b/apps/api/src/routes/eval.ts
@@ -45,11 +45,15 @@ router.post('/', async (req, res, next) => {
     const cases = raw
       .trim()
       .split('\n')
-      .map((line) => JSON.parse(line) as {
-        id: string;
-        input: string;
-        expected: string;
-      });
+      .map(
+        (line) =>
+          // eslint-disable-next-line implicit-arrow-linebreak
+          JSON.parse(line) as {
+            id: string;
+            input: string;
+            expected: string;
+          },
+      );
 
     const openai = new OpenAI({
       apiKey: process.env.OPENAI_API_KEY,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "main": "src/main.tsx",
   "scripts": {
     "dev": "vite",
-    "build": "tsc",
+    "build": "vite build",
     "lint": "eslint . --ext .ts,.tsx --max-warnings 0",
     "tsc": "tsc -p tsconfig.json --noEmit"
   },


### PR DESCRIPTION
## Summary
- build the web with `vite build`
- mount Express static middleware to serve the built UI
- add SPA fallback in the API server

## Testing
- `pnpm dev` *(fails: manual Ctrl+C after startup)*
- `pnpm test`
- `pnpm test:e2e`
- `pnpm tsc`
- `pnpm lint`
- `pnpm format`
- `docker build -t promptlab:latest .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c26204abc83298cde88d89ffea774