### PR TITLE
Remove unused imports map from API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,9 +10,6 @@
     "lint": "eslint . --ext .ts,.tsx --max-warnings 0",
     "tsc": "tsc -p tsconfig.json --noEmit"
   },
-  "imports": {
-    "@prompt-lab/evaluator": "../../packages/evaluator/src/index.ts"
-  },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@prompt-lab/evaluator": "workspace:*",


### PR DESCRIPTION
## Summary
- remove the `imports` section from `apps/api/package.json`

## Testing
- `pnpm dev`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm tsc`
- `pnpm lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_685c261cd17883299eb1649d1fa5a3e0