### PR TITLE
Add Gemini key example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 PORT=3000
 OPENAI_API_KEY=your_openai_api_key_here
+GEMINI_API_KEY=your_gemini_api_key_here
+

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ flowchart LR
 
 ---
 
+## 🛠️ Setup
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and provide values for `OPENAI_API_KEY` and `GEMINI_API_KEY`.
+
+---
+
 ## 🚀 Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- document Gemini API key example in `.env.example`
- show how to set API keys in README setup section

## Testing
- `pnpm dev` *(terminated after startup)*
- `pnpm test`
- `pnpm test:e2e`
- `pnpm tsc`
- `pnpm lint`
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_e_685c261fc478832988b378a3dae2f3a7