### PR TITLE
chore(ci): Simplify Node.js matrix to single LTS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 22.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR simplifies the CI pipeline by removing the Node.js version matrix (18.x, 22.x) and
standardizing on a single version: the current Long-Term Support (LTS) release, Node.js 18.x.

The primary motivation is to increase CI efficiency and align the test environment more closely
with the production environment defined in the Dockerfile.

## Type of Change:

   - [ ] Bug fix (non-breaking change which fixes an issue)
   - [ ] New feature (non-breaking change which adds functionality)
   - [ ] Breaking change (fix or feature that would cause existing functionality to not work as
     expected)
   - [ ] Documentation update
   - [x] Refactoring (no functional changes)
   - [x] Performance improvement
   - [ ] Test improvements


##  How Has This Been Tested?

  The change is validated by the successful execution of this PR's own CI pipeline.

   - [x] Unit tests pass
   - [x] Integration tests pass
   - [x] E2E tests pass
   - [ ] Manual testing performed

##  Checklist:


   - [x] My code follows the project's style guidelines
   - [x] I have performed a self-review of my own code
   - [ ] I have commented my code, particularly in hard-to-understand areas
   - [ ] I have made corresponding changes to the documentation
   - [x] My changes generate no new warnings
   - [ ] I have added tests that prove my fix is effective or that my feature works
   - [x] New and existing unit tests pass locally with my changes
   - [ ] Any dependent changes have been merged and published

##  Related Issues:

  N/A

##  Additional Notes:


  By removing the matrix, we gain:
   - Faster CI Feedback: Build times are effectively halved.
   - Reduced Cost: Fewer CI runner minutes are consumed.
   - Better Alignment: The CI environment now more accurately reflects the single Node.js version
     used in the production Docker container.