### PR TITLE
chore: exclude dist from coverage

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,6 +13,9 @@ export default defineConfig({
   test: {
     environment: 'node',
     exclude: ['node_modules/**', '**/dist/**', 'apps/web/**'],
+    coverage: {
+      exclude: ['**/dist/**'],
+    },
     // Vitest will automatically look for workspace configs
     // and run them appropriately.
   },


### PR DESCRIPTION
## Summary
- update root vitest config to exclude compiled `dist` directories from test coverage reports

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ff3c3946c8329bbd747ac5590f60e