### PR TITLE
fix: avoid double serialize job metrics

### DIFF
--- a/packages/api/src/jobs/service.ts
+++ b/packages/api/src/jobs/service.ts
@@ -40,8 +40,7 @@ export async function updateJob(
   const updateData = {
     ...data,
     updatedAt: new Date(),
-    // Ensure metrics is properly serialized
-    ...(data.metrics && { metrics: JSON.stringify(data.metrics) }),
+    ...(data.metrics && { metrics: data.metrics }),
   };
 
   const result = await db

--- a/packages/api/test/jobService.test.ts
+++ b/packages/api/test/jobService.test.ts
@@ -63,18 +63,12 @@ describe('job service', () => {
 
     expect(updated.status).toBe('completed');
     expect(updated.result).toBe('done');
-    const stored =
-      typeof updated.metrics === 'string'
-        ? JSON.parse(updated.metrics)
-        : updated.metrics;
-    expect(stored).toEqual(metrics);
+    expect(typeof updated.metrics).toBe('object');
+    expect(updated.metrics).toEqual(metrics);
 
     const fetched = await getJob(job.id);
     expect(fetched?.status).toBe('completed');
-    const fetchedMetrics =
-      typeof fetched?.metrics === 'string'
-        ? JSON.parse(fetched.metrics as string)
-        : fetched?.metrics;
-    expect(fetchedMetrics).toEqual(metrics);
+    expect(typeof fetched?.metrics).toBe('object');
+    expect(fetched?.metrics).toEqual(metrics);
   });
 });


### PR DESCRIPTION
## Summary
- use object for metrics instead of serialized string in updateJob
- update job service tests to expect metrics as object

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff9617c8c8329a4ca3d00859db806