### PR TITLE
feat: track job cost and tokens

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -14,6 +14,8 @@ export interface JobResult {
   status: 'pending' | 'running' | 'completed' | 'failed';
   result?: string;
   metrics?: Record<string, unknown>;
+  tokensUsed?: number;
+  costUsd?: number;
 }
 
 export interface ApiError {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "audit:fix": "pnpm audit --fix",
     "deps:check": "depcheck --ignores='@types/*,@testing-library/*,@vitejs/*,@vitest/*,eslint-*,@eslint/*,typescript,react-dom,better-sqlite3,get-port,rimraf,supertest' --ignore-patterns='scripts/**/*'",
     "deps:update": "pnpm update --recursive --latest",
-    "prepare": "husky"
+    "prepare": "husky",
+    "migrate": "pnpm exec tsx scripts/migrate.ts"
   },
   "devDependencies": {
     "@eslint/compat": "^1.3.1",

--- a/packages/api/drizzle/migrations/0000_initial.sql
+++ b/packages/api/drizzle/migrations/0000_initial.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `jobs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`prompt` text NOT NULL,
+	`provider` text NOT NULL,
+	`model` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`result` text,
+	`metrics` text,
+	`error_message` text,
+	`created_at` integer DEFAULT (strftime('%s', 'now')) NOT NULL,
+	`updated_at` integer DEFAULT (strftime('%s', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `jobs_status_idx` ON `jobs` (`status`);--> statement-breakpoint
+CREATE INDEX `jobs_created_at_idx` ON `jobs` (`created_at`);--> statement-breakpoint
+CREATE INDEX `jobs_provider_model_idx` ON `jobs` (`provider`,`model`);

--- a/packages/api/drizzle/migrations/0001_add_cost_tokens.sql
+++ b/packages/api/drizzle/migrations/0001_add_cost_tokens.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "jobs" ADD COLUMN "tokens_used" integer;
+--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "cost_usd" real;

--- a/packages/api/drizzle/migrations/meta/0000_snapshot.json
+++ b/packages/api/drizzle/migrations/meta/0000_snapshot.json
@@ -1,0 +1,112 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "9612eef5-6450-4761-81f7-2c0bab25cfc9",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "jobs_status_idx": {
+          "name": "jobs_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "jobs_created_at_idx": {
+          "name": "jobs_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "jobs_provider_model_idx": {
+          "name": "jobs_provider_model_idx",
+          "columns": ["provider", "model"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/packages/api/drizzle/migrations/meta/0001_snapshot.json
+++ b/packages/api/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,126 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "786c8572-f3d5-4a00-8a5f-155fcccecd9b",
+  "prevId": "9612eef5-6450-4761-81f7-2c0bab25cfc9",
+  "tables": {
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now'))"
+        }
+      },
+      "indexes": {
+        "jobs_status_idx": {
+          "name": "jobs_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "jobs_created_at_idx": {
+          "name": "jobs_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "jobs_provider_model_idx": {
+          "name": "jobs_provider_model_idx",
+          "columns": ["provider", "model"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/packages/api/drizzle/migrations/meta/_journal.json
+++ b/packages/api/drizzle/migrations/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1751124233762,
+      "tag": "0000_initial",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1751124115925,
+      "tag": "0001_add_cost_tokens",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -30,8 +30,11 @@ async function initializeDb() {
 
       const __dirname = fileURLToPath(new URL('.', import.meta.url));
       const migrationPath = join(__dirname, '../../drizzle/migrations');
+      const fallbackPath = join(__dirname, '../../../drizzle/migrations');
+      const hasMigrations =
+        existsSync(migrationPath) || existsSync(fallbackPath);
 
-      if (existsSync(migrationPath)) {
+      if (hasMigrations && config.database.url !== ':memory:') {
         await runMigrations();
       } else {
         log.info('No migrations folder found, creating tables manually');
@@ -46,6 +49,8 @@ async function initializeDb() {
             result TEXT,
             metrics TEXT,
             error_message TEXT,
+            tokens_used INTEGER,
+            cost_usd REAL,
             created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
             updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
           );

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -1,4 +1,10 @@
-import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  real,
+} from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 
 export const jobs = sqliteTable(
@@ -16,6 +22,8 @@ export const jobs = sqliteTable(
     result: text('result'),
     metrics: text('metrics', { mode: 'json' }),
     errorMessage: text('error_message'), // New field for error details
+    tokensUsed: integer('tokens_used'),
+    costUsd: real('cost_usd'),
     createdAt: integer('created_at', { mode: 'timestamp' })
       .notNull()
       .default(sql`(strftime('%s', 'now'))`),

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -73,6 +73,8 @@ export interface JobWithTypedMetrics {
   result: string | null;
   metrics: JobMetrics | null;
   errorMessage: string | null;
+  tokensUsed: number | null;
+  costUsd: number | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,6 @@
+import { runMigrations } from '@prompt-lab/api';
+
+runMigrations().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `tokens_used` and `cost_usd` columns to jobs schema
- include new fields in API types
- provide Drizzle migrations for the new columns
- support running migrations via `pnpm migrate`
- handle migrations properly when DATABASE_URL is `:memory:`

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686006b280248329a17a06f0098aca8b