### PR TITLE
feat: track token usage and cost

### DIFF
--- a/packages/api/src/providers/index.ts
+++ b/packages/api/src/providers/index.ts
@@ -9,7 +9,10 @@ export interface ProviderOptions {
 export interface LLMProvider {
   name: string;
   models: string[];
-  complete(prompt: string, options: ProviderOptions): AsyncGenerator<string>;
+  complete(
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<{ output: string; tokens: number; cost: number }>;
 }
 
 const providers: Record<string, LLMProvider> = {

--- a/packages/api/src/providers/pricing.ts
+++ b/packages/api/src/providers/pricing.ts
@@ -1,0 +1,13 @@
+export const PRICING = {
+  openai: {
+    'gpt-4.1-nano': 0.001,
+    'gpt-4.1-mini': 0.003,
+    'gpt-4.1': 0.01,
+    'gpt-4o-mini': 0.002,
+  },
+  gemini: {
+    'gemini-2.5-flash': 0.00025,
+  },
+} as const;
+
+export type ProviderPricing = typeof PRICING;


### PR DESCRIPTION
## Summary
- add pricing map for model costs
- return tokens and cost from provider completions
- persist tokens_used and cost_usd for completed jobs
- compute avgScore for stored metrics
- adjust job streaming route to use new provider API
- test cost and token tracking

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68600c5639488329aba78de249fab32a