### PR TITLE
feat: add job history state

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -132,9 +132,17 @@ export class ApiClient {
 
     return es;
   }
+
+  static async listJobs(): Promise<JobSummary[]> {
+    console.log('📜 Fetching job history');
+    const result = await this.makeRequest<JobSummary[]>('/jobs');
+    console.log('✅ Job history fetched:', result);
+    return result;
+  }
 }
 
 // Legacy exports for backward compatibility
 export const createJob = ApiClient.createJob.bind(ApiClient);
 export const fetchJob = ApiClient.fetchJob.bind(ApiClient);
 export const streamJob = ApiClient.streamJob.bind(ApiClient);
+export const listJobs = ApiClient.listJobs.bind(ApiClient);

--- a/apps/web/src/store/jobStore.ts
+++ b/apps/web/src/store/jobStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { listJobs } from '../api.js';
 import type { JobSummary } from '../api.js';
 
 interface LogLine {
@@ -9,16 +10,19 @@ interface LogLine {
 interface JobState {
   current?: JobSummary;
   log: LogLine[];
+  history: JobSummary[];
   metrics?: Record<string, number>;
   running: boolean;
   start(job: JobSummary): void;
   append(text: string): void;
   finish(metrics: Record<string, number>): void;
   reset(): void;
+  loadHistory(): Promise<void>;
 }
 
 export const useJobStore = create<JobState>((set) => ({
   log: [],
+  history: [],
   running: false,
   start: (job) => {
     console.log('🏁 Store: Starting job', job);
@@ -35,5 +39,14 @@ export const useJobStore = create<JobState>((set) => ({
   reset: () => {
     console.log('🔄 Store: Resetting');
     set({ current: undefined, log: [], metrics: undefined, running: false });
+  },
+  loadHistory: async () => {
+    console.log('📜 Store: Loading history');
+    try {
+      const history = await listJobs();
+      set({ history });
+    } catch (err) {
+      console.error('Failed to load history', err);
+    }
   },
 }));


### PR DESCRIPTION
## Summary
- add `listJobs` API function for fetching job history
- store history in Zustand job store
- add a `loadHistory` action to populate `history`

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_68602748e4a88329a7d236c5327ebd2f