### PR TITLE
feat: add job history drawer

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import LiveOutputPanel from './components/LiveOutputPanel.js';
 import ResultsPanel from './components/ResultsPanel.js';
 import DebugPanel from './components/DebugPanel.js';
 import ErrorAlert from './components/ErrorAlert.js';
+import HistoryDrawer from './components/HistoryDrawer.js';
 
 const App = () => {
   const [template, setTemplate] = useState('');
@@ -13,6 +14,7 @@ const App = () => {
   const [model, setModel] = useState('gpt-4o-mini');
   const [error, setError] = useState('');
   const { log, metrics, running, start, append, finish, reset } = useJobStore();
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   const handleRun = async () => {
     console.log('🚀 Run button clicked!');
@@ -69,11 +71,20 @@ const App = () => {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <div className="bg-white shadow-sm border-b border-gray-200">
-        <div className="mx-auto max-w-4xl px-4 py-6">
-          <h1 className="text-2xl font-bold text-gray-900">Prompt Lab</h1>
-          <p className="text-gray-600 mt-1">
-            Evaluate and test your prompts with real-time streaming
-          </p>
+        <div className="mx-auto max-w-4xl px-4 py-6 flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Prompt Lab</h1>
+            <p className="text-gray-600 mt-1">
+              Evaluate and test your prompts with real-time streaming
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setHistoryOpen(true)}
+            className="text-sm text-blue-600 hover:text-blue-800"
+          >
+            History
+          </button>
         </div>
       </div>
 
@@ -105,6 +116,12 @@ const App = () => {
 
         <ResultsPanel metrics={metrics} />
       </div>
+      {historyOpen && (
+        <HistoryDrawer
+          open={historyOpen}
+          onClose={() => setHistoryOpen(false)}
+        />
+      )}
     </div>
   );
 };

--- a/apps/web/src/components/HistoryDrawer.tsx
+++ b/apps/web/src/components/HistoryDrawer.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+import { fetchJob } from '../api.js';
+import { useJobStore } from '../store/jobStore.js';
+
+interface HistoryDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const HistoryDrawer = ({ open, onClose }: HistoryDrawerProps) => {
+  const { history, loadHistory, start, append, finish, reset } = useJobStore();
+
+  useEffect(() => {
+    loadHistory();
+  }, [loadHistory]);
+
+  const handleSelect = async (id: string) => {
+    try {
+      reset();
+      const job = await fetchJob(id);
+      start({ id: job.id, status: job.status });
+      if (job.result) {
+        append(job.result);
+      }
+      finish((job.metrics as Record<string, number>) || {});
+      onClose();
+    } catch (err) {
+      console.error('Failed to load job', err);
+    }
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 overflow-hidden transition-opacity ${
+        open ? '' : 'pointer-events-none'
+      }`}
+    >
+      <div
+        className={`absolute inset-0 bg-gray-900 bg-opacity-50 transition-opacity ${
+          open ? 'opacity-100' : 'opacity-0'
+        }`}
+        onClick={onClose}
+      />
+      <div
+        className={`absolute inset-y-0 right-0 w-80 max-w-full transform bg-white shadow-xl transition-transform ${
+          open ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        <div className="p-4 border-b flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">History</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="p-4 space-y-2 overflow-y-auto">
+          {history.map((job) => (
+            <button
+              key={job.id}
+              type="button"
+              onClick={() => handleSelect(job.id)}
+              className="w-full text-left p-2 rounded-md border border-gray-200 hover:bg-gray-50"
+            >
+              <div className="flex justify-between">
+                <span className="font-mono text-sm">{job.id}</span>
+                <span className="text-xs text-gray-600">{job.status}</span>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HistoryDrawer;

--- a/apps/web/test/HistoryDrawer.test.tsx
+++ b/apps/web/test/HistoryDrawer.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import HistoryDrawer from '../src/components/HistoryDrawer.js';
+import * as jobStoreModule from '../src/store/jobStore.js';
+import * as apiModule from '../src/api.js';
+
+describe('HistoryDrawer', () => {
+  it('loads history and fetches job on click', async () => {
+    const loadHistory = vi.fn();
+    const start = vi.fn();
+    const append = vi.fn();
+    const finish = vi.fn();
+    const reset = vi.fn();
+
+    vi.spyOn(jobStoreModule, 'useJobStore').mockReturnValue({
+      history: [{ id: 'job1', status: 'completed' }],
+      loadHistory,
+      start,
+      append,
+      finish,
+      reset,
+    } as unknown as ReturnType<typeof jobStoreModule.useJobStore>);
+
+    vi.spyOn(apiModule, 'fetchJob').mockResolvedValue({
+      id: 'job1',
+      status: 'completed',
+      result: 'hello',
+      metrics: { score: 1 },
+    });
+
+    render(<HistoryDrawer open={true} onClose={() => {}} />);
+
+    expect(loadHistory).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('job1'));
+
+    await waitFor(() => {
+      expect(apiModule.fetchJob).toHaveBeenCalledWith('job1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `HistoryDrawer` component for viewing and selecting past jobs
- show a History button in the header
- display history in a slide-over drawer with Tailwind styling
- load history on mount and allow selecting a job
- add tests for the drawer component

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686039ddac108329ae8051c3b7031648