### PR TITLE
feat: add validation for jobs pagination params

### DIFF
--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -89,9 +89,19 @@ jobsRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
       since,
     } = req.query as Record<string, string>;
 
+    const limitNum = Number(limit);
+    if (!Number.isInteger(limitNum) || limitNum < 1 || limitNum > 100) {
+      throw new ValidationError('limit must be an integer between 1 and 100.');
+    }
+
+    const offsetNum = Number(offset);
+    if (!Number.isInteger(offsetNum) || offsetNum < 0) {
+      throw new ValidationError('offset must be a non-negative integer.');
+    }
+
     const options: import('@prompt-lab/api').ListJobsOptions = {
-      limit: Number(limit) || 20,
-      offset: Number(offset) || 0,
+      limit: limitNum,
+      offset: offsetNum,
     };
 
     if (provider) {

--- a/apps/api/test/jobs.list.test.ts
+++ b/apps/api/test/jobs.list.test.ts
@@ -41,4 +41,16 @@ describe('GET /jobs', () => {
     expect(job).toHaveProperty('cost_usd');
     expect(job).toHaveProperty('avgScore');
   });
+
+  it('rejects invalid limit parameter', async () => {
+    const res = await request(server).get('/jobs?limit=0');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('limit must be an integer between 1 and 100.');
+  });
+
+  it('rejects invalid offset parameter', async () => {
+    const res = await request(server).get('/jobs?offset=-5');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('offset must be a non-negative integer.');
+  });
 });


### PR DESCRIPTION
## Summary
- validate `limit` and `offset` query params in `/jobs` route
- test invalid pagination params

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686056f9de648329b92b481910118b13