### PR TITLE
test: add diff workflow e2e and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,38 @@ DATABASE_URL=sqlite://./db.sqlite
 # Web server
 PORT=3000
 
-# Other required variables
-# ...
+# Server host
+HOST=localhost
+
+# OpenAI configuration
+OPENAI_TIMEOUT_MS=15000
+OPENAI_MAX_RETRIES=3
+OPENAI_DEFAULT_MODEL=gpt-4o-mini
+
+# Gemini configuration
+GEMINI_TIMEOUT_MS=15000
+GEMINI_MAX_RETRIES=3
+
+# Rate limiting
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_GLOBAL_MAX=100
+RATE_LIMIT_JOBS_MAX=50
+
+# Evaluation settings
+EVALUATION_TIMEOUT_MS=15000
+EVALUATION_CONCURRENCY=5
+EVALUATION_MAX_CASES=1000
+
+# Logging
+LOG_LEVEL=info
+ENABLE_FILE_LOGGING=false
+LOG_MAX_FILE_SIZE=5242880
+LOG_MAX_FILES=5
+
+# Security
+REQUEST_SIZE_LIMIT=1mb
+TRUST_PROXY=false
+
+# Database connection pool
+DB_MAX_CONNECTIONS=10
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ packages/
 | `PORT`           | ❌ Optional | API server port (default: 3000)           |
 | `DATABASE_URL`   | ❌ Optional | SQLite database path (default: sqlite.db) |
 
+## Comparing Two Runs
+
+Use the **History** drawer's Compare mode to select any two completed runs.
+After picking a pair the app navigates to `/diff` where the text output and
+metric deltas are displayed side by side.
+
+You can also retrieve this information through the API:
+
+```bash
+curl "http://localhost:3000/jobs/<baseJobId>/diff?otherId=<compareJobId>"
+```
+
 ---
 
 ## 🛠️ Development Scripts

--- a/apps/web/test/DiffWorkflow.test.tsx
+++ b/apps/web/test/DiffWorkflow.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import HistoryDrawer from '../src/components/HistoryDrawer.js';
+import DiffPage from '../src/pages/DiffPage.js';
+import * as jobStoreModule from '../src/store/jobStore.js';
+import { ApiClient } from '../src/api.js';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('Diff workflow', () => {
+  it('navigates to diff page and displays deltas', async () => {
+    const state: { comparison: { baseJobId?: string; compareJobId?: string } } =
+      { comparison: {} };
+    const loadHistory = vi.fn();
+    const clearComparison = vi.fn();
+
+    vi.spyOn(jobStoreModule, 'useJobStore').mockReturnValue({
+      history: [
+        { id: 'job1', status: 'completed' },
+        { id: 'job2', status: 'completed' },
+      ],
+      comparison: state.comparison,
+      loadHistory,
+      start: vi.fn(),
+      append: vi.fn(),
+      finish: vi.fn(),
+      reset: vi.fn(),
+      setBaseJob: (id: string) => {
+        state.comparison.baseJobId = id;
+      },
+      setCompareJob: (id: string) => {
+        state.comparison.compareJobId = id;
+      },
+      clearComparison,
+    } as unknown as ReturnType<typeof jobStoreModule.useJobStore>);
+
+    vi.spyOn(ApiClient, 'diffJobs').mockResolvedValue({
+      baseJob: {
+        id: 'job1',
+        status: 'completed',
+        result: 'hello',
+        metrics: { score: 0.5 },
+        tokensUsed: 10,
+        costUsd: 0.02,
+        prompt: '',
+        provider: 'openai',
+        model: 'gpt',
+      },
+      compareJob: {
+        id: 'job2',
+        status: 'completed',
+        result: 'hello world',
+        metrics: { score: 0.7 },
+        tokensUsed: 12,
+        costUsd: 0.03,
+        prompt: '',
+        provider: 'openai',
+        model: 'gpt',
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<HistoryDrawer open onClose={() => {}} />} />
+          <Route path="/diff" element={<DiffPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText('Compare'));
+    fireEvent.click(screen.getByText('job1'));
+    fireEvent.click(screen.getByText('job2'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Job Diff')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('hello').length).toBeGreaterThan(0);
+    expect(screen.getByText('score')).toBeInTheDocument();
+    expect(screen.getByText('0.200')).toBeInTheDocument();
+    expect(screen.getByText('0.010')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- write E2E test covering diff workflow
- document comparing runs in README
- expand `.env.example` with all config vars

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68630609c6548329b826d96a71ba9cd5