### PR TITLE
feat: add dashboard stats endpoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,7 @@ import { log, config } from '@prompt-lab/api';
 import { ApiError } from '@prompt-lab/api';
 import jobsRouter from './routes/jobs.js';
 import healthRouter from './routes/health.js';
+import dashboardRouter from './routes/dashboard.js';
 
 // Resolve repo root from this file location
 const rootDir = fileURLToPath(new URL('../../..', import.meta.url));
@@ -67,6 +68,7 @@ app.get('/health', (_req, res) => {
 });
 
 app.use('/jobs', jobsRateLimit, jobsRouter);
+app.use('/api/dashboard', dashboardRouter);
 
 // Serve built web UI from /public when present
 app.use(express.static(join(rootDir, 'public')));

--- a/apps/api/src/routes/dashboard.ts
+++ b/apps/api/src/routes/dashboard.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import { getDb, db, jobs } from '@prompt-lab/api';
+import { gt } from 'drizzle-orm';
+
+const router = Router();
+
+router.get('/stats', async (req, res) => {
+  const { days } = req.query as Record<string, string | undefined>;
+  const parsed = days === undefined ? 30 : Number(days);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return res
+      .status(400)
+      .json({ error: "Invalid 'days' parameter. Must be a positive integer." });
+  }
+
+  const since = new Date();
+  since.setDate(since.getDate() - parsed);
+
+  await getDb();
+  const rows = await db
+    .select({
+      createdAt: jobs.createdAt,
+      model: jobs.model,
+      metrics: jobs.metrics,
+      costUsd: jobs.costUsd,
+    })
+    .from(jobs)
+    .where(gt(jobs.createdAt, since));
+
+  const scoreMap = new Map<string, { total: number; count: number }>();
+  const costMap = new Map<string, number>();
+
+  for (const row of rows) {
+    const dateKey = row.createdAt.toISOString().slice(0, 10);
+    const avg = (row.metrics as { avgScore?: number } | null)?.avgScore;
+    if (typeof avg === 'number') {
+      const entry = scoreMap.get(dateKey) || { total: 0, count: 0 };
+      entry.total += avg;
+      entry.count += 1;
+      scoreMap.set(dateKey, entry);
+    }
+
+    const cost = row.costUsd ?? 0;
+    costMap.set(row.model, (costMap.get(row.model) ?? 0) + cost);
+  }
+
+  const scoreHistory = Array.from(scoreMap.entries())
+    .sort(([a], [b]) => (a > b ? 1 : -1))
+    .map(([date, { total, count }]) => ({
+      date,
+      avgScore: Number((total / count).toFixed(2)),
+    }));
+
+  const costByModel = Array.from(costMap.entries()).map(([model, total]) => ({
+    model,
+    totalCost: Number(total.toFixed(2)),
+  }));
+
+  res.json({ scoreHistory, costByModel });
+});
+
+export default router;

--- a/apps/api/test/dashboard.test.ts
+++ b/apps/api/test/dashboard.test.ts
@@ -1,0 +1,134 @@
+import type { Server } from 'http';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import supertest from 'supertest';
+import getPort from 'get-port';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getDb, jobs } from '@prompt-lab/api';
+import type { NewJob } from '@prompt-lab/api';
+import { app } from '../src/index.ts';
+
+const TEST_DB_PATH = path.join(__dirname, './dashboard-test-db.sqlite');
+process.env.DATABASE_URL = TEST_DB_PATH;
+
+async function seedJobs(jobsToCreate: NewJob[]) {
+  const db = await getDb();
+  await db.insert(jobs).values(jobsToCreate);
+  return jobsToCreate;
+}
+
+let server: Server;
+let request: supertest.SuperTest<supertest.Test>;
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DB_PATH)) {
+    fs.unlinkSync(TEST_DB_PATH);
+  }
+});
+
+beforeEach(async () => {
+  const port = await getPort();
+  server = app.listen(port);
+  request = supertest(app);
+});
+
+afterEach(async () => {
+  if (server) {
+    server.close();
+  }
+});
+
+describe('GET /api/dashboard/stats', () => {
+  it('returns aggregated stats for the given time range', async () => {
+    const now = new Date();
+    const tenDaysAgo = new Date(now.getTime() - 10 * 86400000);
+    const fiveDaysAgo = new Date(now.getTime() - 5 * 86400000);
+    await seedJobs([
+      {
+        id: 'job-1',
+        prompt: 'a',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        metrics: { avgScore: 0.9 },
+        costUsd: 1.0,
+        createdAt: tenDaysAgo,
+      },
+      {
+        id: 'job-2',
+        prompt: 'b',
+        provider: 'gemini',
+        model: 'gemini-2.5-flash',
+        metrics: { avgScore: 0.8 },
+        costUsd: 0.5,
+        createdAt: tenDaysAgo,
+      },
+      {
+        id: 'job-3',
+        prompt: 'c',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        metrics: { avgScore: 1.0 },
+        costUsd: 0.25,
+        createdAt: fiveDaysAgo,
+      },
+      {
+        id: 'job-old',
+        prompt: 'old',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        metrics: { avgScore: 0.5 },
+        costUsd: 0.1,
+        createdAt: new Date(now.getTime() - 35 * 86400000),
+      },
+    ]);
+
+    const res = await request.get('/api/dashboard/stats?days=30').expect(200);
+
+    expect(res.body).toHaveProperty('scoreHistory');
+    expect(res.body).toHaveProperty('costByModel');
+    expect(Array.isArray(res.body.scoreHistory)).toBe(true);
+    expect(Array.isArray(res.body.costByModel)).toBe(true);
+
+    const dateTen = tenDaysAgo.toISOString().slice(0, 10);
+    const dateFive = fiveDaysAgo.toISOString().slice(0, 10);
+
+    const expectedScoreHistory = [
+      { date: dateTen, avgScore: 0.85 },
+      { date: dateFive, avgScore: 1.0 },
+    ];
+    const expectedCostByModel = [
+      { model: 'gpt-4o-mini', totalCost: 1.25 },
+      { model: 'gemini-2.5-flash', totalCost: 0.5 },
+    ];
+
+    expect(res.body.scoreHistory).toEqual(expectedScoreHistory);
+    expect(res.body.costByModel).toEqual(expectedCostByModel);
+  });
+
+  it('returns 400 for invalid days parameter', async () => {
+    const res = await request.get('/api/dashboard/stats?days=-5').expect(400);
+    expect(res.body).toHaveProperty(
+      'error',
+      "Invalid 'days' parameter. Must be a positive integer.",
+    );
+  });
+
+  it('returns empty arrays when no jobs in range', async () => {
+    const now = new Date();
+    await seedJobs([
+      {
+        id: 'old-job',
+        prompt: 'x',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        metrics: { avgScore: 0.7 },
+        costUsd: 0.4,
+        createdAt: new Date(now.getTime() - 40 * 86400000),
+      },
+    ]);
+
+    const res = await request.get('/api/dashboard/stats?days=1').expect(200);
+    expect(res.body.scoreHistory).toEqual([]);
+    expect(res.body.costByModel).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `/api/dashboard/stats` endpoint for aggregated analytics
- validate the `days` query parameter
- compute score history and cost by model
- mount dashboard router in the API server
- add integration tests for dashboard stats

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68645ee490e48329a213cfdd1365c615